### PR TITLE
intro clips

### DIFF
--- a/current/2025/css/main.css
+++ b/current/2025/css/main.css
@@ -1093,12 +1093,25 @@ h2:has(+ .event-hosts, + .event-labels) {
          * */
         line-height: 1.2;
     }
-    li:after{
+    /* The md to html conversion add a <p> tag inside each <li> tags when
+     * the list is greater than one, we use this to add a comma after each
+     * elements when needed */
+    li > p {
+        margin: 0;
+        display: inline-block;
+    }
+    li > p:after {
         content: ", ";
     }
-    li:first-child:after{
+    li:last-child > p:after{
         content: ""
     }
+}
+/* There is 2 exceptions, 2 titles too big. Instead of reducing every other
+ * titles, we fix the 2 exceptions here */
+#building-a-website-design-system-with-atomic-design-principles-using-penpot > h1,
+#the-state-of-processing-how-we-re-bringing-a-creative-coding-icon-back-to-life > h1 {
+    --font-size: 7.8;
 }
 
 @media print {

--- a/current/2025/program/from_printer_dust_till_graphics_dawn_presentation.md
+++ b/current/2025/program/from_printer_dust_till_graphics_dawn_presentation.md
@@ -1,7 +1,7 @@
 ---
 labels: [printers, PostScript, Ghostscript, XPUB]
 type: talk
-title: "From Printer Dust Till Grahics Dawn"
+title: "From Printer Dust Till Graphics Dawn"
 hosts: [XPUB, Manetta, Joseph]
 ---
 

--- a/current/2025/program/from_printer_dust_till_graphics_dawn_workshop.md
+++ b/current/2025/program/from_printer_dust_till_graphics_dawn_workshop.md
@@ -1,7 +1,7 @@
 ---
 labels: [printers, PostScript, XPUB]
 type: workshop
-title: "From Printer Dust Till Grahics Dawn"
+title: "From Printer Dust Till Graphics Dawn"
 hosts: [XPUB, Manetta, Joseph]
 ---
 

--- a/current/_includes/clips.njk
+++ b/current/_includes/clips.njk
@@ -17,7 +17,7 @@
                 {{ logo_boxes | safe}}
                 {{ logo_text | safe}}
                 {{ reimagination | safe}}
-                <div class="presentation-payload">
+                <div class="presentation-payload" id={{title|slugify}}>
                     {{ content | safe }}
                 </div>
                 <div class="filler filler-1"></div>

--- a/scripts/create-md-for-clips.py
+++ b/scripts/create-md-for-clips.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# this script create the /clips/ files  from the /program/ files
+# ./scripts/create-md-for-clips.py -f current/2025/program/* -t talk
+
+import os
+import argparse
+import frontmatter
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--files', dest='files', help='target files', type=argparse.FileType('r'), nargs='+', required=True)
+parser.add_argument('-t', '--types', dest='types', help='accepted types', type=str, nargs='+', default='talk')
+args = parser.parse_args()
+
+for file in args.files:
+    print(file.name)
+    post = frontmatter.load(file)
+    if 'type' in post:
+        if isinstance(post['type'], str):
+            if post['type'] in args.types:
+                post.content = '''# {{title}}
+
+{% for host in hosts %}
+ * {{host}}
+{% endfor %}
+ '''
+                with open(os.path.join('current', '2025', 'clips', os.path.basename(file.name)), "w") as f:  
+                    f.write(frontmatter.dumps(post))


### PR DESCRIPTION
create-md-for-clips.py: a script to generate the /clips .md files from the /program .md files, small fixes in main.css for the clips layout (comma after each speakers only each needed, title size, etc.). If the hosts lastname are added to the /program files the /clips files will also use them after being generated with create-md-for-clips.py (uses python-frontmatter module).